### PR TITLE
[terminal] add current dir name in cursor head

### DIFF
--- a/filesystem.h
+++ b/filesystem.h
@@ -22,6 +22,7 @@ printdisk - pretty print from root
 
 // assuming only folders
 class FileSystem{
+	string rootName = "/";
 	Folder *root, *cur;
 
 	string prettyPrint(Folder *f, int tabs=0) {
@@ -109,6 +110,11 @@ public:
 	// pretty print root
 	void printdisk() {
 		cout<<this->prettyPrint(this->root);
+	}
+
+	string getCurrentDir() {
+		if(cur == root) return rootName;
+		return cur->Name();
 	}
 
 };

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -55,6 +55,10 @@ void readme() {
 	
 }
 
+void printDirHead(FileSystem *fs) {
+	cout<<"wtf 1.1> ";
+}
+
 bool interact(string inp, FileSystem *fs) {
 	inp=utils::truncateTrailingSpace(inp);
 
@@ -97,12 +101,14 @@ signed main() {
 	FileSystem *fs = new FileSystem();
 	cout<<"\n\n☺☺☺☺☺☺☺☺[WTF]☺☺☺☺☺☺☺☺\nwelcome to funny-terminal\n\n";
 	readme(); cout.flush();
+	printDirHead(fs); cout.flush();
 	
 	while(true) {
 		
 		string inp;
 		getline(cin, inp);
 		if(!interact(inp, fs)) break;
+		printDirHead(fs);
 		cout.flush();
 	}
 

--- a/terminal.cpp
+++ b/terminal.cpp
@@ -56,7 +56,7 @@ void readme() {
 }
 
 void printDirHead(FileSystem *fs) {
-	cout<<"wtf 1.1> ";
+	cout<<"wtf1.1$ "<<fs->getCurrentDir()<<" > " ;
 }
 
 bool interact(string inp, FileSystem *fs) {


### PR DESCRIPTION
 - add current dir name in cursor head
    
    ```
    ☺☺☺☺☺☺☺☺[WTF]☺☺☺☺☺☺☺☺
    welcome to funny-terminal
    
    1. help : to output documentation
    2. mkdir <param path of folder> : make a directory
    3. cd <param path of folder> : change path to the specified directory
    4. ls : list directory
    5. pwd - print current working directory
    6. printdir : print all folders with in the current directory
    7. printdisk : print all folders from root directory
    
    wtf 1.1 / > mkdir hello
    ✅ created directory
    wtf 1.1 / > cd hello
    ✅ changed directory
    wtf 1.1 hello > cd ..
    ✅ changed directory
    wtf 1.1 / > mkdir hello/some
    ✅ created directory
    wtf 1.1 / > cd */some
    ✅ changed directory
    wtf 1.1 some > exit
    ```
